### PR TITLE
svyarpr fix

### DIFF
--- a/R/svyarpr.R
+++ b/R/svyarpr.R
@@ -194,7 +194,7 @@ svyarpr.survey.design <-
       densfun(
         formula = formula,
         design = design,
-        arptv,
+        arptv/percent,
         h = htot,
         FUN = "F",
         na.rm = na.rm


### PR DESCRIPTION
wrong value passed to Fprime
(see section 2 of Osier (2009) appendix)
Is related to the test-compare branch failures (probl. solves the testthat skips; see svyarpr and svypoormed)