### PR TITLE
fix ignorable warning in logarithms for svujdiv and svygei

### DIFF
--- a/R/svygei.R
+++ b/R/svygei.R
@@ -205,7 +205,7 @@ svygei.survey.design <-
     lin <-
       matrix(lin ,
              nrow = length(lin) ,
-             dimnames = list(names(lin) , strsplit(as.character(formula)[[2]] , ' \\+ ')[[1]]))
+             dimnames = list(names(w) , strsplit(as.character(formula)[[2]] , ' \\+ ')[[1]]))
 
     # build result object
     rval <- estimate

--- a/R/svygei.R
+++ b/R/svygei.R
@@ -403,6 +403,12 @@ CalcGEI <-
 # function for linearized functions
 CalcGEI_IF <-
   function(y , w , epsilon) {
+
+    # filter NAs
+    w <- ifelse( is.na(y) , 0 , w)
+    y <- ifelse( w>0 , y , 1 )
+
+    # compute intermediate
     N <- sum(w)
     Ytot <- sum(w * y)
     Ybar <- Ytot / N

--- a/R/svyjdiv.R
+++ b/R/svyjdiv.R
@@ -379,8 +379,10 @@ CalcJDiv <-  function(y , w) {
 
 # function to compute linearized function
 CalcJDiv_IF <-  function(y , w) {
+
   # filter NAs
-  w <- ifelse(is.na(y) , 0 , w)
+  w <- ifelse( is.na(y) , 0 , w)
+  y <- ifelse( w>0 , y , 1 )
 
   # compute intermediate statistics
   Ntot <- sum(w)


### PR DESCRIPTION
this is just to fix an annoying (but harmless) warning for log of negative values. If the observation weight is already zero, than it shouldn't matter. 